### PR TITLE
Fix installing with uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ Repository = "https://github.com/nikoraes/pyjexl-extended"
 Playground = "https://nikoraes.github.io/jexl-playground/"
 
 [tool.setuptools.packages]
-find = { where = ["."], exclude = ["tests*"] }
+find = { include = ["pyjexl"], exclude = ["tests*"] }
 
 [tool.setuptools]
 include-package-data = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ Repository = "https://github.com/nikoraes/pyjexl-extended"
 Playground = "https://nikoraes.github.io/jexl-playground/"
 
 [tool.setuptools.packages]
-find = { where = ["pyjexl"], exclude = ["tests*"] }
+find = { where = ["."], exclude = ["tests*"] }
 
 [tool.setuptools]
 include-package-data = true


### PR DESCRIPTION
Uv install failed with `pyjexl` not being installed as a package. Seems that the issue is in the find clause, where `pyjexl` should be in `include` instead of `where` 